### PR TITLE
feat: refresh theme colors and responsiveness

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -23,7 +23,7 @@ export default function Page({
       <AboutSection />
       <TreatmentsSection />
       <ResultsSection />
-      <section className="bg-white">
+      <section className="bg-[hsl(var(--color-forest-muted))]">
         <div className="mx-auto max-w-6xl px-4 py-16">
           <VideoGrid />
         </div>

--- a/app/components/AboutSection.tsx
+++ b/app/components/AboutSection.tsx
@@ -13,22 +13,22 @@ export default function AboutSection() {
   const highlights = content?.highlights ?? [];
 
   return (
-    <section id="about" className="scroll-mt-24 bg-neutral-50">
+    <section id="about" className="scroll-mt-24 bg-[hsl(var(--color-forest-soft))]">
       <div className="mx-auto grid max-w-6xl gap-10 px-4 py-16 md:grid-cols-[1.1fr_0.9fr] md:items-center">
         <div className="space-y-6">
-          <span className="inline-block rounded-full bg-white px-3 py-1 text-xs font-semibold text-neutral-600">
+          <span className="inline-block rounded-full bg-white px-3 py-1 text-xs font-semibold text-[hsl(var(--color-muted))]">
             {t("eyebrow")}
           </span>
           <h2 className="text-3xl font-semibold tracking-tight md:text-4xl">
             {t("title")}
           </h2>
-          <p className="text-lg text-neutral-600">{t("subtitle")}</p>
-          <div className="space-y-4 text-neutral-600">
+          <p className="text-lg text-[hsl(var(--color-muted))]">{t("subtitle")}</p>
+          <div className="space-y-4 text-[hsl(var(--color-muted))]">
             {body.map((paragraph, idx) => (
               <p key={idx}>{paragraph}</p>
             ))}
           </div>
-          <ul className="grid gap-2 text-sm text-neutral-700 md:grid-cols-2">
+          <ul className="grid gap-2 text-sm text-[hsl(var(--color-forest))] md:grid-cols-2">
             {highlights.map((item, idx) => (
               <li key={idx} className="flex items-start gap-2">
                 <span aria-hidden className="mt-1 h-2 w-2 rounded-full bg-[hsl(var(--brand))]" />

--- a/app/components/ContactSection.tsx
+++ b/app/components/ContactSection.tsx
@@ -21,17 +21,17 @@ export default function ContactSection() {
   const whatsappHref = whatsappNumber.replace(/\D+/g, "");
 
   return (
-    <section id="contact" className="scroll-mt-24 bg-neutral-50">
+    <section id="contact" className="scroll-mt-24 bg-[hsl(var(--color-forest-soft))]">
       <div className="mx-auto grid max-w-6xl gap-10 px-4 py-16 md:grid-cols-[0.9fr_1.1fr] md:items-start">
         <div className="space-y-6">
-          <span className="inline-block rounded-full bg-white px-3 py-1 text-xs font-semibold text-neutral-600">
+          <span className="inline-block rounded-full bg-white px-3 py-1 text-xs font-semibold text-[hsl(var(--color-muted))]">
             {t("eyebrow")}
           </span>
           <h2 className="text-3xl font-semibold tracking-tight md:text-4xl">
             {t("title")}
           </h2>
-          <p className="text-lg text-neutral-600">{t("description")}</p>
-          <div className="space-y-4 rounded-3xl border border-neutral-200 bg-white p-6 text-neutral-700">
+          <p className="text-lg text-[hsl(var(--color-muted))]">{t("description")}</p>
+          <div className="space-y-4 rounded-3xl border border-white/40 bg-white/90 p-6 text-[hsl(var(--color-forest))] shadow-[0_18px_50px_-32px_rgba(35,64,62,0.65)]">
             <div>
               <p className="text-xs uppercase tracking-widest text-neutral-400">
                 {t("phoneLabel")}
@@ -60,46 +60,46 @@ export default function ContactSection() {
           </div>
         </div>
         <form
-          className="space-y-5 rounded-3xl border border-neutral-200 bg-white p-6 shadow-[0_24px_60px_-40px_rgba(15,23,42,0.35)]"
+          className="space-y-5 rounded-3xl border border-white/40 bg-white/95 p-6 shadow-[0_32px_90px_-45px_rgba(35,64,62,0.5)]"
           aria-label={form?.title}
         >
-          <h3 className="text-xl font-semibold text-neutral-900">{form?.title}</h3>
+          <h3 className="text-xl font-semibold text-[hsl(var(--color-forest))]">{form?.title}</h3>
           <div className="grid gap-4 md:grid-cols-2">
-            <label className="flex flex-col text-sm text-neutral-600">
+            <label className="flex flex-col text-sm text-[hsl(var(--color-muted))]">
               {form?.fields.name}
               <input
                 type="text"
                 name="name"
-                className="mt-2 rounded-2xl border border-neutral-200 px-4 py-3 text-neutral-900 focus:border-[hsl(var(--brand))] focus:outline-none focus:ring-2 focus:ring-[hsl(var(--brand))]/40"
+                className="mt-2 rounded-2xl border border-white/60 px-4 py-3 text-neutral-900 focus:border-[hsl(var(--brand))] focus:outline-none focus:ring-2 focus:ring-[hsl(var(--brand))]/40"
                 placeholder={form?.fields.name}
                 required
               />
             </label>
-            <label className="flex flex-col text-sm text-neutral-600">
+            <label className="flex flex-col text-sm text-[hsl(var(--color-muted))]">
               {form?.fields.email}
               <input
                 type="email"
                 name="email"
-                className="mt-2 rounded-2xl border border-neutral-200 px-4 py-3 text-neutral-900 focus:border-[hsl(var(--brand))] focus:outline-none focus:ring-2 focus:ring-[hsl(var(--brand))]/40"
+                className="mt-2 rounded-2xl border border-white/60 px-4 py-3 text-neutral-900 focus:border-[hsl(var(--brand))] focus:outline-none focus:ring-2 focus:ring-[hsl(var(--brand))]/40"
                 placeholder={form?.fields.email}
                 required
               />
             </label>
-            <label className="flex flex-col text-sm text-neutral-600 md:col-span-2">
+            <label className="flex flex-col text-sm text-[hsl(var(--color-muted))] md:col-span-2">
               {form?.fields.country}
               <input
                 type="text"
                 name="country"
-                className="mt-2 rounded-2xl border border-neutral-200 px-4 py-3 text-neutral-900 focus:border-[hsl(var(--brand))] focus:outline-none focus:ring-2 focus:ring-[hsl(var(--brand))]/40"
+                className="mt-2 rounded-2xl border border-white/60 px-4 py-3 text-neutral-900 focus:border-[hsl(var(--brand))] focus:outline-none focus:ring-2 focus:ring-[hsl(var(--brand))]/40"
                 placeholder={form?.fields.country}
               />
             </label>
-            <label className="flex flex-col text-sm text-neutral-600 md:col-span-2">
+            <label className="flex flex-col text-sm text-[hsl(var(--color-muted))] md:col-span-2">
               {form?.fields.message}
               <textarea
                 name="message"
                 rows={4}
-                className="mt-2 rounded-2xl border border-neutral-200 px-4 py-3 text-neutral-900 focus:border-[hsl(var(--brand))] focus:outline-none focus:ring-2 focus:ring-[hsl(var(--brand))]/40"
+                className="mt-2 rounded-2xl border border-white/60 px-4 py-3 text-neutral-900 focus:border-[hsl(var(--brand))] focus:outline-none focus:ring-2 focus:ring-[hsl(var(--brand))]/40"
                 placeholder={form?.fields.message}
                 required
               />

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -3,11 +3,9 @@ import { useTranslations } from "next-intl";
 export default function Footer() {
   const t = useTranslations("footer");
   return (
-    <footer className="border-t">
-      <div className="mx-auto max-w-6xl px-4 py-10 text-sm text-neutral-600">
-        <p>
-          © {new Date().getFullYear()} Atria Hair Clinic · {t("rights")}
-        </p>
+    <footer className="border-t border-white/10 bg-[hsl(var(--color-forest))] text-[hsl(var(--color-contrast))]">
+      <div className="mx-auto max-w-6xl px-4 py-10 text-sm text-white/75">
+        <p>© {new Date().getFullYear()} Atria Hair Clinic · {t("rights")}</p>
       </div>
     </footer>
   );

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import LangSwitcher from "./lang-switcher";
@@ -6,29 +7,31 @@ import LangSwitcher from "./lang-switcher";
 export default function Header({ locale }: { locale: "az" | "ru" | "en" |"tr" }) {
   const t = useTranslations("nav");
   return (
-    <header className="sticky top-0 z-50 bg-white/70 backdrop-blur supports-[backdrop-filter]:bg-white/60 border-b">
-      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
-        <Link href="/" className="flex items-center gap-2">
-          <img src="/logo.svg" alt="Logo" className="h-8 w-8" />
-          <span className="font-bold">Atria</span>
+    <header className="sticky top-0 z-50 border-b border-white/10 bg-[hsl(var(--color-forest))]/95 text-[hsl(var(--color-contrast))] shadow-sm backdrop-blur supports-[backdrop-filter]:bg-[hsl(var(--color-forest))]/80">
+      <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-4 py-3 md:flex-nowrap">
+        <Link href="/" className="flex items-center gap-2 text-[hsl(var(--color-contrast))]">
+          <Image src="/logo.svg" alt="Atria logo" width={32} height={32} className="h-8 w-8" priority />
+          <span className="text-lg font-semibold tracking-tight">Atria</span>
         </Link>
-        <nav className="hidden gap-6 md:flex">
-          <Link href="#about" className="hover:opacity-80">
+        <nav className="hidden gap-6 text-sm font-medium md:flex">
+          <Link href="#about" className="text-white/80 transition hover:text-white">
             {t("about")}
           </Link>
-          <Link href="#treatments" className="hover:opacity-80">
+          <Link href="#treatments" className="text-white/80 transition hover:text-white">
             {t("treatments")}
           </Link>
-          <Link href="#results" className="hover:opacity-80">
+          <Link href="#results" className="text-white/80 transition hover:text-white">
             {t("results")}
           </Link>
-          <Link href="#contact" className="hover:opacity-80">
+          <Link href="#contact" className="text-white/80 transition hover:text-white">
             {t("contact")}
           </Link>
         </nav>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
           <LangSwitcher current={locale} />
-          <a href="#contact" className="btn btn-primary text-sm">{t("book")}</a>
+          <a href="#contact" className="btn btn-primary text-sm shadow-[0_10px_30px_-12px_rgba(244,162,97,0.9)] hover:shadow-[0_12px_34px_-10px_rgba(244,162,97,0.95)]">
+            {t("book")}
+          </a>
         </div>
       </div>
     </header>

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -4,21 +4,22 @@ import { useTranslations } from "next-intl";
 export default function Hero() {
   const t = useTranslations("hero");
   return (
-    <section className="relative isolate overflow-hidden">
+    <section className="relative isolate overflow-hidden bg-[hsl(var(--color-forest-soft))]">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_right,_rgba(35,64,62,0.12),_transparent_55%)]" />
       <div className="mx-auto grid max-w-6xl grid-cols-1 items-center gap-10 px-4 py-16 md:grid-cols-2 md:py-24">
         <div className="space-y-6">
-          <span className="inline-block rounded-full bg-neutral-100 px-3 py-1 text-xs font-medium">
+          <span className="inline-block rounded-full bg-[hsl(var(--color-forest-muted))] px-3 py-1 text-xs font-medium text-[hsl(var(--color-forest))]">
             {t("badge")}
           </span>
-          <h1 className="text-4xl font-bold tracking-tight md:text-5xl">
+          <h1 className="text-4xl font-bold tracking-tight text-[hsl(var(--color-forest))] md:text-5xl">
             {t("title")}<span className="text-[hsl(var(--brand))]"> Atria</span>
           </h1>
-          <p className="text-neutral-600 text-lg">{t("subtitle")}</p>
+          <p className="text-lg text-[hsl(var(--color-muted))]">{t("subtitle")}</p>
           <div className="flex flex-wrap gap-3 pt-2">
             <a href="#contact" className="btn btn-primary">{t("cta")}</a>
             <a href="#results" className="btn btn-ghost">{t("cta2")}</a>
           </div>
-          <ul className="mt-4 grid grid-cols-2 gap-2 text-sm text-neutral-600 md:max-w-md">
+          <ul className="mt-4 grid grid-cols-2 gap-2 text-sm text-[hsl(var(--color-muted))] md:max-w-md">
             <li>✓ FUE / DHI / Sapphire</li>
             <li>✓ PRP & post‑op care</li>
             <li>✓ Sterile ORs</li>

--- a/app/components/ResultsSection.tsx
+++ b/app/components/ResultsSection.tsx
@@ -11,33 +11,40 @@ export default function ResultsSection() {
   const cases = (t.raw("cases") as CaseStudy[]) ?? [];
 
   return (
-    <section id="results" className="scroll-mt-24 bg-neutral-900 text-white">
+    <section
+      id="results"
+      className="relative scroll-mt-24 overflow-hidden bg-[hsl(var(--color-forest-dark))] text-[hsl(var(--color-contrast))]"
+    >
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.12),_transparent_55%)]" />
       <div className="mx-auto max-w-6xl px-4 py-16">
         <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
           <div className="max-w-2xl space-y-4">
-            <span className="inline-block rounded-full bg-white/10 px-3 py-1 text-xs font-semibold text-white/80">
+            <span className="inline-block rounded-full bg-white/15 px-3 py-1 text-xs font-semibold text-white/80">
               {t("eyebrow")}
             </span>
             <h2 className="text-3xl font-semibold tracking-tight md:text-4xl">
               {t("title")}
             </h2>
-            <p className="text-lg text-white/80">{t("description")}</p>
+            <p className="text-lg text-white/85">{t("description")}</p>
           </div>
-          <p className="text-sm text-white/60 md:max-w-xs">{t("note")}</p>
+          <p className="text-sm text-white/65 md:max-w-xs">{t("note")}</p>
         </div>
         <div className="mt-12 grid gap-6 md:grid-cols-3">
           {cases.map((item, idx) => (
             <article
               key={`${item.name}-${idx}`}
-              className="flex h-full flex-col justify-between rounded-3xl border border-white/10 bg-white/5 p-6"
+              className="flex h-full flex-col justify-between rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur-sm transition hover:border-white/20 hover:bg-white/10"
             >
               <div className="space-y-3">
                 <h3 className="text-xl font-semibold text-white">{item.name}</h3>
-                <p className="text-sm text-white/70">{item.summary}</p>
+                <p className="text-sm text-white/75">{item.summary}</p>
               </div>
               <ul className="mt-6 space-y-3 text-sm text-white/80">
                 {item.metrics.map((metric, metricIdx) => (
-                  <li key={metricIdx} className="flex items-center justify-between gap-3 rounded-2xl bg-white/5 px-4 py-2">
+                  <li
+                    key={metricIdx}
+                    className="flex items-center justify-between gap-3 rounded-2xl bg-white/10 px-4 py-2"
+                  >
                     <span>{metric}</span>
                     <span aria-hidden className="h-2 w-2 rounded-full bg-[hsl(var(--brand))]" />
                   </li>

--- a/app/components/StatsStrip.tsx
+++ b/app/components/StatsStrip.tsx
@@ -10,14 +10,17 @@ export default function StatsStrip() {
   const items = (t.raw("items") as StatItem[]) ?? [];
 
   return (
-    <section className="bg-neutral-900 text-white" aria-label={t("ariaLabel")}>
+    <section
+      className="bg-[hsl(var(--color-forest))] text-[hsl(var(--color-contrast))]"
+      aria-label={t("ariaLabel")}
+    >
       <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-10 md:flex-row md:items-center md:justify-between">
         {items.map((item, idx) => (
           <div key={idx} className="text-center md:text-left">
             <p className="text-3xl font-semibold tracking-tight md:text-4xl">
               {item.value}
             </p>
-            <p className="mt-1 text-sm text-white/70 md:text-base">{item.label}</p>
+            <p className="mt-1 text-sm text-white/75 md:text-base">{item.label}</p>
           </div>
         ))}
       </div>

--- a/app/components/TreatmentsSection.tsx
+++ b/app/components/TreatmentsSection.tsx
@@ -11,26 +11,26 @@ export default function TreatmentsSection() {
   const items = (t.raw("items") as TreatmentItem[]) ?? [];
 
   return (
-    <section id="treatments" className="scroll-mt-24">
+    <section id="treatments" className="scroll-mt-24 bg-white">
       <div className="mx-auto max-w-6xl px-4 py-16">
         <div className="mx-auto max-w-3xl text-center">
-          <span className="inline-block rounded-full bg-neutral-100 px-3 py-1 text-xs font-semibold text-neutral-600">
+          <span className="inline-block rounded-full bg-[hsl(var(--color-forest-muted))] px-3 py-1 text-xs font-semibold text-[hsl(var(--color-forest))]">
             {t("eyebrow")}
           </span>
           <h2 className="mt-4 text-3xl font-semibold tracking-tight md:text-4xl">
             {t("title")}
           </h2>
-          <p className="mt-4 text-lg text-neutral-600">{t("description")}</p>
+          <p className="mt-4 text-lg text-[hsl(var(--color-muted))]">{t("description")}</p>
         </div>
         <div className="mt-12 grid gap-6 md:grid-cols-3">
           {items.map((item, idx) => (
             <article
               key={`${item.name}-${idx}`}
-              className="flex h-full flex-col rounded-3xl border border-neutral-200 bg-white p-6 text-left shadow-[0_24px_60px_-40px_rgba(15,23,42,0.35)]"
+              className="flex h-full flex-col rounded-3xl border border-white/60 bg-white p-6 text-left shadow-[0_30px_80px_-50px_rgba(35,64,62,0.35)]"
             >
               <h3 className="text-xl font-semibold text-neutral-900">{item.name}</h3>
-              <p className="mt-2 text-sm text-neutral-600">{item.summary}</p>
-              <ul className="mt-6 space-y-3 text-sm text-neutral-700">
+              <p className="mt-2 text-sm text-[hsl(var(--color-muted))]">{item.summary}</p>
+              <ul className="mt-6 space-y-3 text-sm text-[hsl(var(--color-forest))]">
                 {item.points.map((point, pointIdx) => (
                   <li key={pointIdx} className="flex items-start gap-2">
                     <span aria-hidden className="mt-1 h-1.5 w-1.5 rounded-full bg-[hsl(var(--brand))]" />

--- a/app/components/VideoGrid.tsx
+++ b/app/components/VideoGrid.tsx
@@ -10,10 +10,13 @@ export default function VideoGrid() {
   const videos = (t.raw("items") as VideoItem[]) ?? [];
   return (
     <div>
-      <h2 className="mb-6 text-2xl font-semibold">{t("title")}</h2>
+      <h2 className="mb-6 text-2xl font-semibold text-[hsl(var(--color-forest))]">{t("title")}</h2>
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
         {videos.map((v, idx) => (
-          <figure key={idx} className="overflow-hidden rounded-2xl border">
+          <figure
+            key={idx}
+            className="overflow-hidden rounded-2xl border border-white/60 bg-white/90 shadow-[0_20px_60px_-45px_rgba(35,64,62,0.55)]"
+          >
             <iframe
               className="aspect-video w-full"
               src={v.src}
@@ -22,7 +25,7 @@ export default function VideoGrid() {
               referrerPolicy="strict-origin-when-cross-origin"
               allowFullScreen
             />
-            <figcaption className="px-4 py-2 text-sm text-neutral-600">{v.title}</figcaption>
+            <figcaption className="px-4 py-3 text-sm text-[hsl(var(--color-muted))]">{v.title}</figcaption>
           </figure>
         ))}
       </div>

--- a/app/components/lang-switcher.tsx
+++ b/app/components/lang-switcher.tsx
@@ -163,8 +163,8 @@ export default function LocaleSwitcher({ current }: { current?: Loc }) {
             }
           }}
           className={[
-            "cursor-pointer inline-flex items-center justify-center rounded-2xl px-2.5 py-1.5",
-            "bg-transparent hover:bg-white/10 transition",
+            "cursor-pointer inline-flex items-center justify-center rounded-2xl px-2.5 py-1.5 text-white",
+            "bg-white/5 hover:bg-white/10 transition",
             open
               ? "ring-1 ring-white/30 shadow-[0_0_24px_-10px_rgba(255,255,255,0.5)]"
               : "",
@@ -196,9 +196,8 @@ export default function LocaleSwitcher({ current }: { current?: Loc }) {
           onKeyDown={onMenuKeyDown}
           className={[
             "absolute right-0 mt-2 w-20 origin-top-right",
-            "rounded-2xl border border-white/10 backdrop-blur",
-            "bg-mainColor shadow-lg ring-1 ring-black/5",
-            "transition will-change-transform",
+            "rounded-2xl border border-white/10 bg-[hsl(var(--color-forest))] text-white shadow-lg",
+            "ring-1 ring-black/5 backdrop-blur transition will-change-transform",
             open
               ? "scale-100 opacity-100"
               : "pointer-events-none scale-95 opacity-0",
@@ -215,8 +214,8 @@ export default function LocaleSwitcher({ current }: { current?: Loc }) {
                   onClick={() => onSelect(code)}
                   className={[
                     "w-full flex items-center justify-center gap-1 rounded-xl p-2 cursor-pointer",
-                    "hover:bg-white/15 focus:bg-white/15 focus:outline-none",
-                    code === active ? "ring-1 ring-white/30" : "",
+                    "hover:bg-white/10 focus:bg-white/10 focus:outline-none",
+                    code === active ? "ring-1 ring-white/40" : "",
                   ].join(" ")}
                 >
                   <Flag />

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,15 +1,24 @@
 @import "tailwindcss";
 
 :root {
-  --brand: 38 92% 52%;
+  /* brand palette */
+  --color-forest: 176 29% 19%; /* rgb(35, 64, 62) */
+  --color-forest-dark: 176 31% 14%;
+  --color-forest-muted: 168 25% 92%;
+  --color-forest-soft: 166 33% 96%;
+  --color-contrast: 0 0% 100%;
+  --color-muted: 168 11% 38%;
+
+  --brand: 26 87% 67%;
+  --brand-contrast: 27 91% 16%;
 }
 
 .btn {
   @apply inline-flex items-center justify-center rounded-2xl px-5 py-3 font-semibold shadow-sm transition active:scale-[.98];
 }
 .btn-primary {
-  @apply bg-[hsl(var(--brand))] text-white hover:opacity-95;
+  @apply bg-[hsl(var(--brand))] text-[hsl(var(--brand-contrast))] hover:bg-[hsl(var(--brand))]/90;
 }
 .btn-ghost {
-  @apply bg-transparent text-neutral-900 hover:bg-neutral-100;
+  @apply bg-transparent text-[hsl(var(--color-forest))] hover:bg-[hsl(var(--color-forest-muted))];
 }


### PR DESCRIPTION
## Summary
- define a reusable color palette and update button styles around the new brand colors
- recolor the header, hero, and primary sections to the requested green scheme while adjusting text contrast and responsiveness
- refresh supporting sections (videos, contact, footer) to match the palette and ensure linting can run with a project ESLint config

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d54b99bb2483249b839ba8f82eb497